### PR TITLE
10 - added new map for mobile

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,10 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { MapComponent } from './map/map.component';
 import { GeojsonComponent } from './geojson/geojson.component';
+import { MobileComponent } from './mobile/mobile.component';
 
 const routes: Routes = [
   { path: 'basic', component: MapComponent },
   { path: 'vector-data', component: GeojsonComponent },
+  { path: 'mobile', component: MobileComponent },
   { path: '', redirectTo: '/basic', pathMatch: 'full' },
 ];
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,5 +2,6 @@
 <nav>
   <a routerLink="/basic">Basic</a>
   <a routerLink="/vector-data">Vector Data</a>
+  <a routerLink="/mobile">Mobile Map</a>
 </nav>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,12 +5,14 @@ import { AppComponent } from './app.component';
 import { MapComponent } from './map/map.component';
 import { GeojsonComponent } from './geojson/geojson.component';
 import { AppRoutingModule } from './app-routing.module';
+import { MobileComponent } from './mobile/mobile.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     MapComponent,
-    GeojsonComponent
+    GeojsonComponent,
+    MobileComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/mobile/mobile.component.css
+++ b/src/app/mobile/mobile.component.css
@@ -1,0 +1,6 @@
+#map-container {
+  margin: 0;
+  height: 90vh;
+  width: 90vw;
+  font-family: "Courier New", Courier, monospace;
+}

--- a/src/app/mobile/mobile.component.html
+++ b/src/app/mobile/mobile.component.html
@@ -1,0 +1,1 @@
+<div id="map-container"></div>

--- a/src/app/mobile/mobile.component.ts
+++ b/src/app/mobile/mobile.component.ts
@@ -1,0 +1,36 @@
+import { Component, AfterViewInit } from '@angular/core';
+
+import { Map, View } from 'ol';
+import TileLayer from 'ol/layer/Tile';
+import { fromLonLat } from 'ol/proj';
+import OSM from 'ol/source/OSM';
+
+@Component({
+  selector: 'app-mobile',
+  templateUrl: './mobile.component.html',
+  styleUrls: ['./mobile.component.css'],
+})
+export class MobileComponent implements AfterViewInit {
+  map?: Map;
+
+  constructor() {}
+
+  ngAfterViewInit(): void {
+    this.initMap();
+  }
+
+  initMap() {
+    this.map = new Map({
+      target: 'map-container',
+      layers: [
+        new TileLayer({
+          source: new OSM(),
+        }),
+      ],
+      view: new View({
+        center: fromLonLat([-46.5, -23.5]),
+        zoom: 5,
+      }),
+    });
+  }
+}


### PR DESCRIPTION
This is a basic map, until now, nothing special has been added. To use the browser's `geolocation` HTTPS is needed, so [https://ngrok.com/](https://ngrok.com/) was used. 

After configurations, the map could be served as `./path/to/ngrok http 4200 --host-header="localhost:4200"` and a HTTPS link will be generated by ngrok.
